### PR TITLE
pypi.python org now rejects http requests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ PYPI_PASSWD_FILE="${PYPI_PASSWD_FILE:-${PYPI_ROOT}/.htpasswd}"
 # make sure the passwd file exists
 touch "${PYPI_PASSWD_FILE}"
 
-_extra=""
+_extra="--fallback-url https://pypi.python.org/simple"
 
 # allow existing packages to be overwritten
 if [[ "${PYPI_OVERWRITE}" != "" ]]; then


### PR DESCRIPTION
Temporarily change fallback-url until upstream does so

...

Can you do something like this? See:

https://github.com/pypiserver/pypiserver/issues/179#issuecomment-339705185
